### PR TITLE
fix: sandbox findings — gRPC example, OTel bug, docs, CI Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,22 @@ jobs:
           version: v2.8
 
   test:
-    runs-on: ubuntu-latest
+    # Cross-platform matrix so Windows-specific regressions (unix build
+    # tags missing a fallback, path separators, signal handling,
+    # GOOS-gated syscalls) can't ride to main unnoticed.
+    #
+    # We keep -race on linux where it's cheapest; windows runners get
+    # the same test set without -race because the Windows race
+    # detector has historically been slow and noisy on GitHub runners.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            race: "-race"
+          - os: windows-latest
+            race: ""
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
@@ -33,4 +48,4 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test -race -count=1 -timeout 120s ./...
+        run: go test ${{ matrix.race }} -count=1 -timeout 180s ./...

--- a/README.md
+++ b/README.md
@@ -296,6 +296,13 @@ s.Use(gomcp.BearerAuthSkipHandshake(tokenValidator))
 s.Use(gomcp.APIKeyAuthSkipHandshake("X-API-Key", keyValidator))
 ```
 
+> **Auth error shape.** When a BearerAuth / APIKeyAuth / BasicAuth /
+> RequireRole / RequirePermission middleware rejects a call, the
+> framework returns a regular JSON-RPC `result` with
+> `isError = true` and the reason in `content[0].text` — **not** a
+> JSON-RPC `error` object, and **not** an HTTP 401/403. Clients must
+> inspect the tool-call result's `isError` to detect auth failures.
+
 **Custom middleware:**
 
 ```go
@@ -371,6 +378,26 @@ s.AsyncTool("report", "Generate report", func(ctx *gomcp.Context) (*gomcp.CallTo
 ```go
 s.LoadDir("./tools/", gomcp.DirOptions{Watch: true})
 ```
+
+YAML tool file shape:
+
+```yaml
+name: search
+description: Full-text document search
+version: "1.0"            # OPTIONAL — non-empty renames the tool to "search@1.0"
+method: GET
+handler: https://example.com/search
+params:
+  - {name: query, type: string, required: true, description: Query text}
+```
+
+> **Heads up — `version` renames the tool.** A non-empty `version`
+> field makes the Provider register the tool as `name@version`
+> (e.g. `search@1.0`), following the same convention as
+> [`gomcp.Version()`](#component-versioning). That is the name
+> clients must pass to `tools/call`, and the name that shows up in
+> `tools/list`. Drop the `version` field entirely if you want an
+> unversioned tool called plain `search`.
 
 <a id="server-lifecycle"></a>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -281,6 +281,13 @@ s.Use(gomcp.BearerAuthSkipHandshake(tokenValidator))
 s.Use(gomcp.APIKeyAuthSkipHandshake("X-API-Key", keyValidator))
 ```
 
+> **认证错误的返回形态。** 当 BearerAuth / APIKeyAuth / BasicAuth /
+> RequireRole / RequirePermission 中间件拒绝一次调用时，框架会返回
+> 一个普通的 JSON-RPC `result`，其中 `isError = true` 且
+> `content[0].text` 里是拒绝原因——**不是** JSON-RPC 的 `error`
+> 对象，**也不是** HTTP 401/403。客户端需要检查工具调用结果的
+> `isError` 字段来判断鉴权失败。
+
 ### 工具分组
 
 ```go
@@ -339,6 +346,24 @@ s.AsyncTool("report", "生成报告", handler)
 ```go
 s.LoadDir("./tools/", gomcp.DirOptions{Watch: true})
 ```
+
+YAML tool 文件格式：
+
+```yaml
+name: search
+description: 全文档搜索
+version: "1.0"            # 可选——非空会把 tool 名改成 "search@1.0"
+method: GET
+handler: https://example.com/search
+params:
+  - {name: query, type: string, required: true, description: 查询关键字}
+```
+
+> **注意——`version` 会改写 tool 名。** YAML 里非空的 `version` 字段
+> 会让 Provider 把 tool 注册为 `name@version`（例如 `search@1.0`），
+> 与 [`gomcp.Version()`](#组件版本化) 的约定一致。这也是客户端调用
+> `tools/call` 时必须使用的名字，以及 `tools/list` 里展示的名字。
+> 如果希望保留 `search` 这样的无版本名，直接删掉 `version` 字段即可。
 
 <a id="server-lifecycle"></a>
 

--- a/examples/grpc-adapter/main.go
+++ b/examples/grpc-adapter/main.go
@@ -1,0 +1,124 @@
+// Command grpc-adapter shows how to import a gRPC service as MCP tools
+// using adapter.ImportGRPC.
+//
+// The example wires the standard grpc.health.v1.Health service into an
+// MCP stdio server so Claude Desktop / Cursor / Kiro can call
+// HealthCheck as a tool. No protoc is required — we reuse the
+// generated types shipped with google.golang.org/grpc/health.
+//
+// Flow:
+//  1. Start a gRPC server on a loopback port.
+//  2. Register the Health service + reflection (ImportGRPC discovers
+//     services via server reflection).
+//  3. Dial the server with grpc.NewClient.
+//  4. adapter.ImportGRPC registers each unary method as an MCP tool.
+//     Streaming methods are skipped.
+//  5. Serve MCP over stdio.
+//
+// The resulting tool is "health.check" (service name snake-cased +
+// method name snake-cased). Call it with {"service":""} for the
+// overall SERVING status, or {"service":"example.svc"} for a named
+// component.
+//
+// Usage with Claude Desktop:
+//
+//	{
+//	  "mcpServers": {
+//	    "grpc-health": {
+//	      "command": "go",
+//	      "args": ["run", "./examples/grpc-adapter"]
+//	    }
+//	  }
+//	}
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/zhangpanda/gomcp"
+	"github.com/zhangpanda/gomcp/adapter"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// buildServer wires the gRPC backend and the MCP server together,
+// returning the MCP server plus a cleanup function that tears down
+// both the gRPC server and the dialed client. Separated from main()
+// so tests can drive the same setup without calling Stdio().
+func buildServer() (*gomcp.Server, func(), error) {
+	// 1. start gRPC on loopback:0 so parallel runs don't collide.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("listen: %w", err)
+	}
+	grpcAddr := lis.Addr().String()
+
+	gsrv := grpc.NewServer()
+	hsrv := health.NewServer()
+	// Mark the overall status + a named component as SERVING so
+	// callers see something interesting rather than the default
+	// SERVICE_UNKNOWN.
+	hsrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	hsrv.SetServingStatus("example.svc", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(gsrv, hsrv)
+	// Reflection is what ImportGRPC uses to discover services.
+	reflection.Register(gsrv)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- gsrv.Serve(lis) }()
+
+	// 2. dial ourselves. Insecure credentials are fine here — it is
+	// loopback only and the connection is not reused outside this
+	// process.
+	conn, err := grpc.NewClient(grpcAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		gsrv.Stop()
+		return nil, nil, fmt.Errorf("dial: %w", err)
+	}
+
+	// 3. build the MCP server and import all unary gRPC methods.
+	s := gomcp.New("grpc-adapter-demo", "1.0.0")
+	s.Use(gomcp.Logger())
+
+	if err := adapter.ImportGRPC(s, conn, adapter.GRPCOptions{
+		// Bound reflection discovery: a wedged server must not hang
+		// startup forever.
+		Timeout: 10 * time.Second,
+		// Filter explicitly to the health service. ImportGRPC already
+		// drops reflection itself, but being explicit documents intent
+		// and keeps this example focused.
+		Services: []string{"grpc.health.v1.Health"},
+	}); err != nil {
+		_ = conn.Close()
+		gsrv.Stop()
+		return nil, nil, fmt.Errorf("import grpc: %w", err)
+	}
+
+	log.Printf("grpc-adapter: imported gRPC at %s as MCP tools", grpcAddr)
+
+	cleanup := func() {
+		_ = conn.Close()
+		gsrv.GracefulStop()
+	}
+	return s, cleanup, nil
+}
+
+func main() {
+	s, cleanup, err := buildServer()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := s.Stdio(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/grpc-adapter/main_test.go
+++ b/examples/grpc-adapter/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zhangpanda/gomcp/mcptest"
+)
+
+// TestBuildServer_ImportsHealthCheck asserts that the gRPC adapter
+// example really imports grpc.health.v1.Health/Check as an MCP tool
+// and that a round-trip call reaches the dynamic protobuf request
+// builder end-to-end. Uses mcptest so we can exercise the MCP server
+// in-process without the stdio transport.
+func TestBuildServer_ImportsHealthCheck(t *testing.T) {
+	s, cleanup, err := buildServer()
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	defer cleanup()
+
+	c := mcptest.NewClient(t, s)
+	c.Initialize()
+
+	// grpcToolName lowercases the trailing service name and snake-
+	// cases the method. For grpc.health.v1.Health/Check that is
+	// "health.check".
+	tools := c.ListTools()
+	if !containsTool(tools, "health.check") {
+		t.Fatalf("expected health.check tool, got %v", tools)
+	}
+
+	// Probe the overall status.
+	res := c.CallTool("health.check", map[string]any{"service": ""})
+	res.AssertNoError(t)
+	if !strings.Contains(res.Text(), "SERVING") {
+		t.Errorf("empty-service probe: expected SERVING, got %q", res.Text())
+	}
+
+	// Named component must also serve, proving arguments round-trip
+	// through dynamicpb.
+	res = c.CallTool("health.check", map[string]any{"service": "example.svc"})
+	res.AssertNoError(t)
+	if !strings.Contains(res.Text(), "SERVING") {
+		t.Errorf("example.svc probe: expected SERVING, got %q", res.Text())
+	}
+}
+
+func containsTool(tools []string, want string) bool {
+	for _, t := range tools {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/gin-gonic/gin v1.12.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
@@ -26,6 +27,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/integration_stdio_proc_other_test.go
+++ b/integration_stdio_proc_other_test.go
@@ -1,0 +1,19 @@
+//go:build !unix
+
+package gomcp_test
+
+import "os/exec"
+
+// setSubprocessGroup is a no-op on platforms that do not expose unix
+// process groups. Callers fall back to plain cmd.Process.Kill().
+func setSubprocessGroup(_ *exec.Cmd) {}
+
+// killSubprocessGroup signals the primary child only on non-unix
+// platforms. `go run` grandchildren may leak, but that is the
+// pre-existing behaviour and CI only runs on unix anyway.
+func killSubprocessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+}

--- a/integration_stdio_proc_unix_test.go
+++ b/integration_stdio_proc_unix_test.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package gomcp_test
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setSubprocessGroup places the command in its own process group so
+// killSubprocessGroup can reach every descendant (including the
+// grandchild binary spawned by `go run`). Called before cmd.Start().
+func setSubprocessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killSubprocessGroup sends SIGKILL to the negative PID, which unix
+// resolves to the entire process group we created above. Falls back
+// to a direct Kill if the group id lookup fails (e.g. the child has
+// already exited on its own).
+func killSubprocessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		return
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+}

--- a/integration_stdio_test.go
+++ b/integration_stdio_test.go
@@ -20,11 +20,22 @@ func TestIntegration_Stdio_FullFlow(t *testing.T) {
 		t.Skip("skipping stdio integration test in short mode")
 	}
 
-	// Start filesystem server as subprocess
+	// Start filesystem server as subprocess.
+	//
+	// go run spawns the compiled binary as a grandchild, so a plain
+	// cmd.Process.Kill() only reaps the wrapper and can leave the
+	// real server running. Put the whole tree in one process group
+	// so we can signal every descendant via the negative PID idiom
+	// (see setSubprocessGroup / killSubprocessGroup below). The
+	// filesystem example also exits on stdin EOF, which is what
+	// saves this test today — the belt-and-suspenders here is to
+	// keep integration tests robust if a future server handler is
+	// less graceful about stdin closing.
 	cmd := exec.Command("go", "run", "./examples/filesystem")
 	cmd.Dir = projectRoot(t)
 	cmd.Env = append(os.Environ(), "FS_ROOT="+t.TempDir())
 	cmd.Stderr = os.Stderr
+	setSubprocessGroup(cmd)
 
 	stdin, _ := cmd.StdinPipe()
 	stdout, _ := cmd.StdoutPipe()
@@ -35,9 +46,9 @@ func TestIntegration_Stdio_FullFlow(t *testing.T) {
 		t.Fatalf("start server: %v", err)
 	}
 	defer func() {
-		stdin.Close()
-		cmd.Process.Kill()
-		cmd.Wait()
+		_ = stdin.Close()
+		killSubprocessGroup(cmd)
+		_ = cmd.Wait()
 	}()
 
 	time.Sleep(500 * time.Millisecond)

--- a/middleware_auth.go
+++ b/middleware_auth.go
@@ -56,6 +56,21 @@ func getHeader(ctx *Context, key string) string {
 }
 
 // --- Auth Middleware ---
+//
+// Error shape for Auth and RBAC middleware (BearerAuth, APIKeyAuth,
+// BasicAuth, RequireRole, RequirePermission):
+//
+// When any of these middleware fails, the returned error is wrapped by
+// the server's request pipeline into a normal JSON-RPC result with
+// the tool-level flag IsError=true. It is not surfaced as a
+// JSON-RPC error object (i.e. the response has "result.isError" =
+// true, "result.content[0].text" = "auth: ...", and no "error" key).
+//
+// Clients that only inspect the JSON-RPC "error" field will miss
+// auth failures; inspect the tools/call result's IsError instead.
+// This is also why 401/403 are not emitted as HTTP status codes on
+// the Streamable-HTTP transport — the transport always responds with
+// 200 OK and the refusal lives inside the JSON-RPC result.
 
 // TokenValidator validates a bearer token and returns claims (stored in context as "_auth_claims").
 // Implement JWT or opaque-token checks yourself inside validate; this package does not parse JWTs.
@@ -253,6 +268,10 @@ func BasicAuth(validate func(username, password string) (map[string]any, error))
 }
 
 // --- Authorization Middleware ---
+//
+// RequireRole and RequirePermission follow the same error-shape rule
+// as the auth middleware above: a failed check is returned as a
+// tools/call result with IsError=true, not as a JSON-RPC error.
 
 // RequireRole returns a middleware that checks if the authenticated user has the required role.
 // Roles are read from ctx store key "_auth_roles" (set by auth middleware).

--- a/provider.go
+++ b/provider.go
@@ -23,10 +23,17 @@ type DirOptions struct {
 }
 
 // toolDef is the YAML tool definition format.
+//
+// A non-empty Version changes the registered tool name to
+// "<Name>@<Version>" (e.g. Name="search" + Version="1.0" is exposed
+// as "search@1.0" in tools/list and is called with the versioned
+// name in tools/call). This is the framework's versioning convention
+// — see [Version] for details. Leave Version empty for an
+// unversioned tool.
 type toolDef struct {
 	Name        string     `yaml:"name"`
 	Description string     `yaml:"description"`
-	Version     string     `yaml:"version"`
+	Version     string     `yaml:"version"` // optional; non-empty renames tool to "Name@Version"
 	Params      []paramDef `yaml:"params"`
 	Handler     string     `yaml:"handler"` // HTTP URL to forward to
 	Method      string     `yaml:"method"`  // HTTP method (default GET)

--- a/regression_close_eviction_test.go
+++ b/regression_close_eviction_test.go
@@ -1,0 +1,131 @@
+package gomcp_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zhangpanda/gomcp"
+)
+
+// TestRegression_CloseDuringEvictionNoDeadlock hammers Server.Close()
+// in parallel with tight eviction sweeps. Previous Close() revisions
+// serialized shutdown behind s.mu and could block an in-flight
+// evictIdle that held session locks; a slow sweep could then wedge
+// Close forever.
+//
+// The current shape — closeOnce + sessions.close() closing a
+// dedicated done channel — should be race-safe. This test locks
+// that behaviour in: after Close returns, further sweeps must be
+// no-ops and must not deadlock, panic, or resurrect the server.
+func TestRegression_CloseDuringEvictionNoDeadlock(t *testing.T) {
+	const sessions = 200
+	const sweepers = 4
+	const sweepLoops = 500
+
+	s := gomcp.New("t", "1.0")
+	sm := s.Sessions()
+
+	// Seed a pile of sessions so the eviction sweep actually has work
+	// to iterate through rather than returning on an empty map.
+	for i := 0; i < sessions; i++ {
+		sm.Get("sess-" + itoa(i))
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Sweepers: call evictIdle with a past-TTL "now" on one third of
+	// the iterations and a present "now" on the other two thirds,
+	// mimicking the real ticker that runs every minute against a mix
+	// of idle and active sessions.
+	for w := 0; w < sweepers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if i%3 == 0 {
+					sm.EvictIdleForTest(time.Now().Add(time.Hour))
+				} else {
+					sm.EvictIdleForTest(time.Now())
+				}
+				if i >= sweepLoops {
+					return
+				}
+			}
+		}()
+	}
+
+	// A toucher goroutine keeps new sessions flowing so Close meets
+	// an actually-loaded manager, not a freshly-drained one.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			sm.Get("live-" + itoa(i%17))
+			if i >= sweepLoops {
+				return
+			}
+		}
+	}()
+
+	// Give the background goroutines ~5ms to make some noise, then
+	// call Close from the main goroutine with a hard deadline.
+	time.Sleep(5 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		s.Close()
+		s.Close() // idempotency check — must not hang on the second call
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("Close() did not return within 3s — deadlock against eviction sweep")
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// A post-Close sweep must still be harmless. Previously the
+	// sessions field would have been nil'd out, which we don't want
+	// to regress into: existing holders of *SessionManager would
+	// crash.
+	sm.EvictIdleForTest(time.Now())
+}
+
+// itoa is a tiny stdlib-free integer formatter so this test file can
+// avoid pulling in strconv just for the session-seeding loop.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/regression_tool_name_test.go
+++ b/regression_tool_name_test.go
@@ -1,0 +1,89 @@
+package gomcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zhangpanda/gomcp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestRegression_OTelSeesToolName guards against the bug where the
+// outer middleware chain fired before _tool_name was populated,
+// making OpenTelemetry spans come out as "mcp.tool.unknown" instead
+// of "mcp.tool.<name>". Same fix unblocks PrometheusMetrics and any
+// user-authored middleware that reads ctx.Get("_tool_name").
+//
+// handleRequestInternal now peeks tools/call params and sets
+// _tool_name on the outer context before the chain runs.
+func TestRegression_OTelSeesToolName(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	s := gomcp.New("t", "1.0")
+	s.Use(gomcp.OpenTelemetryWithProvider(tp))
+	s.Tool("traced", "emits span",
+		func(ctx *gomcp.Context) (*gomcp.CallToolResult, error) {
+			return ctx.Text("ok"), nil
+		},
+	)
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"traced","arguments":{}}}`)
+	_ = s.HandleRaw(context.Background(), req)
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatalf("no spans emitted")
+	}
+	for _, sp := range spans {
+		if sp.Name == "mcp.tool.traced" {
+			return
+		}
+	}
+	names := make([]string, 0, len(spans))
+	for _, sp := range spans {
+		names = append(names, sp.Name)
+	}
+	t.Fatalf("expected mcp.tool.traced, got %v", names)
+}
+
+// TestRegression_MetricsSeesToolName mirrors the above for
+// PrometheusMetrics: previously the tool label ended up as "" because
+// the middleware ran at the outer chain level, before _tool_name was
+// set by handleToolsCall. After the fix, the counter must be bumped
+// for the exact tool name.
+func TestRegression_MetricsSeesToolName(t *testing.T) {
+	mw, metrics := gomcp.PrometheusMetrics()
+
+	s := gomcp.New("t", "1.0")
+	s.Use(mw)
+	s.Tool("measured", "",
+		func(ctx *gomcp.Context) (*gomcp.CallToolResult, error) {
+			return ctx.Text("ok"), nil
+		},
+	)
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"measured","arguments":{}}}`)
+	_ = s.HandleRaw(context.Background(), req)
+
+	// Probe the Prometheus text-format handler: the exposed
+	// gomcp_tool_calls_total series must carry the real tool label.
+	rr := httptest.NewRecorder()
+	metrics.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rr.Body.String()
+
+	want := `gomcp_tool_calls_total{tool="measured"} 1`
+	if !strings.Contains(body, want) {
+		t.Fatalf("metrics output missing %q\n--- body ---\n%s", want, body)
+	}
+	// Explicitly reject the old broken shape so a regression jumps
+	// out: empty label or missing counter.
+	if strings.Contains(body, `gomcp_tool_calls_total{tool=""} `) {
+		t.Fatalf("metrics regressed: empty tool label present\n%s", body)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -383,6 +383,26 @@ func (s *Server) handleRequestInternal(ctx context.Context, msg *jsonrpcMessage)
 	base := newContext(ctx, mergedArgsForMiddleware(msg), s.logger)
 	base.Set("_mcp_method", msg.Method)
 
+	// Pre-extract the tool name for tools/call so middlewares that
+	// read "_tool_name" (OpenTelemetry span naming, PrometheusMetrics
+	// labels, custom audit chains) actually see it.
+	//
+	// Previously "_tool_name" was only set deep inside handleToolsCall,
+	// after the outer middleware chain had already fired. OTel spans
+	// came out as "mcp.tool.unknown" and Prometheus counters got
+	// empty-string tool labels — the middleware was effectively
+	// blind to which tool it was wrapping. Peeking once here avoids
+	// that without rerouting the chain through every per-method
+	// handler.
+	if msg.Method == "tools/call" && len(msg.Params) > 0 {
+		var p struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(msg.Params, &p); err == nil && p.Name != "" {
+			base.Set("_tool_name", p.Name)
+		}
+	}
+
 	var resp *jsonrpcMessage
 	var chainErr error
 	func() {


### PR DESCRIPTION
## Summary

End-to-end sandbox testing (22 scenarios across 5 tiers) surfaced 5 issues. This PR fixes all of them.

### Bug fix
- **`_tool_name` invisible to outer middleware** — `OpenTelemetry()` emitted `mcp.tool.unknown`, `PrometheusMetrics()` bucketed under empty label. Root cause: `_tool_name` was set inside `handleToolsCall` (on a forked child context) after the middleware chain had already fired on the outer context. Fix: peek `tools/call` params and set `_tool_name` before `executeChain`.

### New example
- `examples/grpc-adapter` — self-contained binary using grpc/health + reflection. No protoc needed.

### Docs
- Auth middleware error shape (`isError=true` result, not JSON-RPC error)
- Provider `version` field renames tool to `name@version`

### Test infra
- `integration_stdio_test.go`: Setpgid + killGroup for robust subprocess cleanup
- `regression_tool_name_test.go`: OTel span name + Prometheus label assertions
- `regression_close_eviction_test.go`: Close() vs concurrent eviction stress test
- CI matrix adds `windows-latest`

### Verified
- `go test -race -count=1 ./...` all green
- `GOOS=windows go test -c` all packages compile
- 22 e2e scenarios PASS