### PR TITLE
Add Xquik OpenAPI adapter example

### DIFF
--- a/examples/openapi-adapter/xquik/README.md
+++ b/examples/openapi-adapter/xquik/README.md
@@ -1,0 +1,14 @@
+# Xquik OpenAPI Adapter Example
+
+This example imports a small Xquik OpenAPI fixture and exposes the
+`searchXquikTweets` operation as an MCP tool.
+
+## Run
+
+```bash
+export XQUIK_BEARER_TOKEN="<your-xquik-bearer-token>"
+go run ./examples/openapi-adapter/xquik
+```
+
+The fixture uses `https://xquik.com` as the server URL and keeps the example
+read-only by importing the tweet search endpoint.

--- a/examples/openapi-adapter/xquik/main.go
+++ b/examples/openapi-adapter/xquik/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/zhangpanda/gomcp"
+	"github.com/zhangpanda/gomcp/adapter"
+)
+
+func main() {
+	authToken := os.Getenv("XQUIK_BEARER_TOKEN")
+	if authToken == "" {
+		log.Fatal("set XQUIK_BEARER_TOKEN before starting the Xquik example")
+	}
+
+	s := gomcp.New("xquik-openapi", "1.0.0")
+	err := adapter.ImportOpenAPI(s, "examples/openapi-adapter/xquik/xquik.openapi.yaml", adapter.OpenAPIOptions{
+		AuthToken: authToken,
+		ServerURL: "https://xquik.com",
+		TagFilter: []string{"xquik"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	s.Stdio()
+}

--- a/examples/openapi-adapter/xquik/xquik.openapi.yaml
+++ b/examples/openapi-adapter/xquik/xquik.openapi.yaml
@@ -1,0 +1,50 @@
+openapi: 3.1.0
+info:
+  title: Xquik Search Example
+  version: "1.0.0"
+servers:
+  - url: https://xquik.com
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchXquikTweets
+      summary: Search public X posts
+      tags:
+        - xquik
+      security:
+        - oauthBearer: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Maximum results to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          required: false
+          description: Pagination cursor from a previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Search results.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+components:
+  securitySchemes:
+    oauthBearer:
+      type: http
+      scheme: bearer


### PR DESCRIPTION
## Summary

- Add a Xquik OpenAPI adapter example for the public tweet search endpoint.
- Use `https://xquik.com` as the API base URL and read auth from `XQUIK_BEARER_TOKEN`.
- Keep the fixture limited to a read endpoint so the example is safe to inspect and run.

## Validation

- Focused Go tests passed for `adapter` and the new example package.
- Git whitespace check passed.
